### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/src/app/api/debug/pagarme/route.js
+++ b/src/app/api/debug/pagarme/route.js
@@ -16,10 +16,12 @@ export async function GET() {
       const sampleLen = Array.isArray(data?.data) ? data.data.length : null;
       ping = { ok: true, status: 200, sample: sampleLen };
     } catch (e) {
+      // Log full error with stack trace server-side for diagnostics
+      console.error("pagarmeGET error:", e);
       ping = {
         ok: false,
         status: e?.status || 0,
-        data: e?.data || String(e),
+        data: e?.message || "Internal error",
       };
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/victorsantosyt/lopesul-dashboard/security/code-scanning/1](https://github.com/victorsantosyt/lopesul-dashboard/security/code-scanning/1)

To fix the problem, we should avoid exposing stack traces or sensitive error details in the HTTP response. Instead, send a sanitized error message to the client and log the full error server-side for diagnostics. In this context, within the inner catch block (lines 18-24), replace the assignment of `data: e?.data || String(e)` with a more generic message (e.g., `data: "Internal error"` or, if we expect a non-sensitive message, use `e?.message || "Internal error"`). Additionally, log the full error including any stack trace on the server using `console.error`. The only changes required are in the block from lines 18-24 in src/app/api/debug/pagarme/route.js; no additional dependencies or imports needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
