### PR TITLE
fix(mikrotik): add explicit named exports for API routes compatibility

### DIFF
--- a/src/lib/mikrotik.js
+++ b/src/lib/mikrotik.js
@@ -56,6 +56,16 @@ export async function revogarCliente(options = {}) {
 export async function liberarClienteNoMikrotik(options = {}) {
   return liberarAcesso(options);
 }
+ // === Named exports explícitos ===
+export {
+  getStarlinkStatus,
+  revogarAcesso,
+  liberarAcesso,
+  liberarCliente,
+  listPppActive,
+  revogarCliente,            // alias
+  liberarClienteNoMikrotik,  // alias
+};
 
 // === Export default ===
 export default {


### PR DESCRIPTION
## Contexto
Durante o deploy, o Next.js falhava no build com erros como:


Isso acontecia porque no `mikrotik.js` tínhamos apenas:

```js
export default { getStarlinkStatus, revogarAcesso, ... }
Adicionados named exports explícitos no final do src/lib/mikrotik.js.

Mantido também o export default (backward compatible).

Nenhuma alteração de lógica interna, apenas correção de exports para o bundler reconhecer.
// === Named exports explícitos ===
export {
  getStarlinkStatus,
  revogarAcesso,
  liberarAcesso,
  liberarCliente,
  listPppActive,
  revogarCliente,            // alias
  liberarClienteNoMikrotik,  // alias
};

// === Export default ===
export default {
  getStarlinkStatus,
  revogarAcesso,
  revogarCliente,            // alias
  liberarAcesso,
  liberarCliente,
  liberarClienteNoMikrotik,  // alias
  listPppActive,
};

