### PR TITLE
fix(api): corrigir imports de mikrotik e alinhar aliases

### DIFF
--- a/src/app/api/mikrotik/revogar/route.js
+++ b/src/app/api/mikrotik/revogar/route.js
@@ -2,7 +2,9 @@
 export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
-import { revogarAcesso } from '@/lib/mikrotik';
+// ajuste: importa default e desestrutura
+import mikrotik from '@/lib/mikrotik';
+const { revogarAcesso } = mikrotik;
 
 const ipv4 =
   /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$/;


### PR DESCRIPTION
- Ajustados os imports das rotas para usar o default export de src/lib/mikrotik.js, evitando erros de build por exports duplicados.
- Alinhados aliases (`revogarCliente`, `liberarCliente`, `liberarClienteNoMikrotik`) para manter compatibilidade com rotas antigas e novas.
- Corrigidas rotas: • /api/liberar-acesso • /api/revogar-acesso • /api/webhook/pagarme • /api/mikrotik/ppp-active • /api/mikrotik/revogar

Com isso, removemos os conflitos de export duplicado e garantimos que os imports fiquem consistentes com a lib mikrotik.